### PR TITLE
修复表格渲染问题

### DIFF
--- a/pages/get.py
+++ b/pages/get.py
@@ -39,15 +39,23 @@ for route in routes:
         name = f'{path}/readme.md'
         userfilename = os.path.join(os.path.dirname(os.path.dirname(__file__)), username)
         filename = os.path.join(os.path.dirname(os.path.dirname(__file__)), name)
+        filename2 = os.path.join(os.path.dirname(os.path.dirname(__file__)), name2)
+        filename3 = os.path.join(os.path.dirname(os.path.dirname(__file__)), name3)
         try:
             input_file = codecs.open(userfilename, mode="r", encoding="utf-8")
         except: 
             try:
                 input_file = codecs.open(filename, mode="r", encoding="utf-8")
             except:
-                return 'None'
+                try:
+                    input_file = codecs.open(filename2, mode="r", encoding="utf-8")
+                except:
+                    try:
+                        input_file = codecs.open(filename3, mode="r", encoding="utf-8")
+                    except:
+                        return 'None'
         text = input_file.read()
-        html = markdown.markdown(text)
+        html = markdown.markdown(text, extensions=['markdown.extensions.fenced_code', 'markdown.extensions.tables'])
         return html
 
 @bot.server_app.route('/autohelp/jsondata')


### PR DESCRIPTION
不同repo的readme有大小写区分，这样的修复方式比较暴力，可以看看有什么更优雅的方式