### PR TITLE
一些小小的功能改进

### DIFF
--- a/pages/black.json
+++ b/pages/black.json
@@ -1,0 +1,5 @@
+[
+    "autohelp",
+    "_feedback_",
+    "_help_"
+]

--- a/pages/pages.py
+++ b/pages/pages.py
@@ -1,10 +1,15 @@
 import os
 import nonebot
-from quart import Blueprint,render_template
+from quart import Blueprint, render_template, Markup
 from hoshino import Service, priv, config
+from hoshino.config import MODULES_ON
 from pathlib import Path
+import markdown
+import json
 
 public_address = "127.0.0.1"#修改为服务器公网ip
+SERVICE_MODE = False # true为服务模式，即读取插件名字和插件help
+# false则读取modules文件夹下插件名字以及对应的userreadme或readme
 
 
 sv_help = '''
@@ -35,9 +40,87 @@ bot = nonebot.get_bot()
 app = bot.server_app
 sv.logger.info(homework_folder)
 
+service_help = None
+
+
+def load_black_list():
+    '''获取不想被放出帮助的插件列表'''
+    _path = os.path.join(os.path.dirname(__file__), 'black.json')
+    if os.path.exists(_path):
+        with open(_path, "r") as f:
+            black = json.load(f)
+        return set(black)
+    else:
+        sv.logger.warning(f"black.json 文件不存在")
+
+
+def get_readme_path(module_name):
+    '''获取module的帮助路径'''
+    READMEs = ["userreadme.md", "readme.md",
+               "README.md", "README.MD", "readme.MD"]
+    base = os.path.join(os.getcwd(), 'hoshino', 'modules', module_name)
+    print(base)
+    readme_path = None
+    for readme in READMEs:
+        file_path = os.path.join(base, readme)
+        if os.path.exists(file_path):
+            readme_path = file_path
+            break
+    return readme_path
+
+
+def load_modules_readme():
+    '''获取module的帮助'''
+    svs = [] 
+    black = load_black_list()
+    for module in MODULES_ON:
+        if module in black:
+            continue
+        readme_path = get_readme_path(module)
+        help = "None"
+        if readme_path is not None:
+            with open(readme_path, "r") as f:
+                help = f.read()
+        svs.append({"name": module, "help": help})
+    return svs
+
+def load_services_readme():
+    '''获取服务的帮助'''
+    services = Service.get_loaded_services()
+    black = load_black_list()
+    svs = []
+    for _, sv in services.items():
+        if sv.name in black:
+            continue
+        help = "None" if sv.help is None else sv.help
+        svs.append({"name": sv.name, "help": help})
+    return svs
+
+def init():
+    '''帮助文案初始化'''
+    global service_help
+
+    if SERVICE_MODE:
+        services = load_services_readme()
+    else:
+        services = load_modules_readme()
+    services.sort(key=lambda data:data["name"])
+    service_help = []
+    id = 0
+    for sv in services:
+        # Markup防止html渲染时html的tag符号被转移
+        html = Markup(markdown.markdown(sv["help"], extensions=[
+                      'markdown.extensions.fenced_code', 'markdown.extensions.tables']))
+        service_help.append({"id": id, "name": sv["name"], "help": html})
+        id += 1
+
+
 @hp.route('/bot/help')
 async def index():
-    return await render_template('help.html')
+    global service_help
+    if service_help is None:
+        init()
+    return await render_template('help.html', services=service_help)
 
 @sv.on_fullmatch("帮助网页版",only_to_me=False)
 async def get_uploader_url(bot, ev):

--- a/pages/templates/help.html
+++ b/pages/templates/help.html
@@ -25,6 +25,7 @@
 		<link href="{{ url_for('static', filename='pcr/css/magnific-popup.css') }}" rel="stylesheet" type="text/css">
 		<link href="{{ url_for('static', filename='pcr/css/jquery-countdown.css') }}" rel="stylesheet" type="text/css">
 		<link href="{{ url_for('static', filename='pcr/css/style2.css') }}" rel="stylesheet"  >
+		<link href="{{ url_for('static', filename='pcr/css/markdown.css') }}" rel="stylesheet">
 
 		<!-- color scheme -->
 		<link id="colors" href="{{ url_for('static', filename='pcr/css/scheme-03.css') }}" rel="stylesheet" type="text/css">
@@ -142,7 +143,7 @@
 														data-tab="accordion-{{service.id}}" style="background-size: cover;">
 														{{ service.name }}
 													</div>
-													<div class="accordion-section-content"
+													<div class="accordion-section-content markdown-body"
 														id="accordion-{{service.id}}" style="background-size: cover;">
 														{{ service.help }}
 													</div>
@@ -290,6 +291,7 @@
 		$(function () {
 			$(".accordion-section").accordion({
 				collapsible: true,
+				heightStyle: "content",
 			});
 		});
 			// var file_urls = [];

--- a/pages/templates/help.html
+++ b/pages/templates/help.html
@@ -1,294 +1,308 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
-<head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-	
-		<title>功能表</title>
-		<meta content="width=device-width, initial-scale=1.0" name="viewport">
-		
-		
-		
-		
 
-		<!--[if lt IE 9]>
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+	<title>功能表</title>
+	<meta content="width=device-width, initial-scale=1.0" name="viewport">
+
+
+
+
+
+	<!--[if lt IE 9]>
     <script src="js/html5shiv.js"></script>
     <![endif]-->
 
-		<!-- CSS Files
+	<!-- CSS Files
     ================================================== -->
-		<link rel="stylesheet" href="{{ url_for('static', filename='pcr/css/bootstrap-4-2-1.css') }}" type="text/css">
-		<link href="{{ url_for('static', filename='pcr/css/bootstrap-grid-min.css') }}" rel="stylesheet" type="text/css">
-		<link href="{{ url_for('static', filename='pcr/css/bootstrap-reboot-min.css') }}" rel="stylesheet" type="text/css">
-		<link href="{{ url_for('static', filename='pcr/css/animate.css') }}" rel="stylesheet" type="text/css">
-		<link href="{{ url_for('static', filename='pcr/css/owl-carousel.css') }}" rel="stylesheet" type="text/css">
-		<link href="{{ url_for('static', filename='pcr/css/owl-theme.css') }}" rel="stylesheet" type="text/css">
-		<link href="{{ url_for('static', filename='pcr/css/owl-transitions.css') }}" rel="stylesheet" type="text/css">
-		<link href="{{ url_for('static', filename='pcr/css/magnific-popup.css') }}" rel="stylesheet" type="text/css">
-		<link href="{{ url_for('static', filename='pcr/css/jquery-countdown.css') }}" rel="stylesheet" type="text/css">
-		<link href="{{ url_for('static', filename='pcr/css/style2.css') }}" rel="stylesheet"  >
-		<link href="{{ url_for('static', filename='pcr/css/markdown.css') }}" rel="stylesheet">
+	<link rel="stylesheet" href="{{ url_for('static', filename='pcr/css/bootstrap-4-2-1.css') }}" type="text/css">
+	<link href="{{ url_for('static', filename='pcr/css/bootstrap-grid-min.css') }}" rel="stylesheet" type="text/css">
+	<link href="{{ url_for('static', filename='pcr/css/bootstrap-reboot-min.css') }}" rel="stylesheet" type="text/css">
+	<link href="{{ url_for('static', filename='pcr/css/animate.css') }}" rel="stylesheet" type="text/css">
+	<link href="{{ url_for('static', filename='pcr/css/owl-carousel.css') }}" rel="stylesheet" type="text/css">
+	<link href="{{ url_for('static', filename='pcr/css/owl-theme.css') }}" rel="stylesheet" type="text/css">
+	<link href="{{ url_for('static', filename='pcr/css/owl-transitions.css') }}" rel="stylesheet" type="text/css">
+	<link href="{{ url_for('static', filename='pcr/css/magnific-popup.css') }}" rel="stylesheet" type="text/css">
+	<link href="{{ url_for('static', filename='pcr/css/jquery-countdown.css') }}" rel="stylesheet" type="text/css">
+	<link href="{{ url_for('static', filename='pcr/css/style2.css') }}" rel="stylesheet">
+	<link href="{{ url_for('static', filename='pcr/css/markdown.css') }}" rel="stylesheet">
 
-		<!-- color scheme -->
-		<link id="colors" href="{{ url_for('static', filename='pcr/css/scheme-03.css') }}" rel="stylesheet" type="text/css">
-		<link href="{{ url_for('static', filename='pcr/css/coloring.css') }}" rel="stylesheet" type="text/css">
+	<!-- color scheme -->
+	<link id="colors" href="{{ url_for('static', filename='pcr/css/scheme-03.css') }}" rel="stylesheet" type="text/css">
+	<link href="{{ url_for('static', filename='pcr/css/coloring.css') }}" rel="stylesheet" type="text/css">
 
-    <!-- RS5.0 Stylesheet -->
-    <link href="{{ url_for('static', filename='pcr/css/settings.css') }}" rel="stylesheet" type="text/css">
+	<!-- RS5.0 Stylesheet -->
+	<link href="{{ url_for('static', filename='pcr/css/settings.css') }}" rel="stylesheet" type="text/css">
 	<link href="{{ url_for('static', filename='pcr/css/layers.css') }}" rel="stylesheet" type="text/css">
-    <link href="{{ url_for('static', filename='pcr/css/navigation.css') }}" rel="stylesheet" type="text/css">
-    <link href="{{ url_for('static', filename='pcr/css/rev-settings.css') }}" rel="stylesheet" type="text/css">
-	
+	<link href="{{ url_for('static', filename='pcr/css/navigation.css') }}" rel="stylesheet" type="text/css">
+	<link href="{{ url_for('static', filename='pcr/css/rev-settings.css') }}" rel="stylesheet" type="text/css">
+
 	<!-- zipfont -->
 	<link href="{{ url_for('static', filename='pcr/css/TXQYW3-embed.css') }}" rel="stylesheet" type="text/css">
-	
+
 	<link href="{{ url_for('static', filename='pcr/css/TXQYW5.css') }}" rel="stylesheet" type="text/css">
 	<link href="{{ url_for('static', filename='pcr/css/TXQYW5-embed.css') }}" rel="stylesheet" type="text/css">
 
 	<!--<audio src="http://d1.027cgb.com/631148/Music/%E6%B0%B7%E3%81%A8%E9%9B%AA%E3%81%AE%E4%B8%96%E7%95%8C.mp3"  autoplay="autoplay" loop="loop" hidden="true" > </audio>	-->
 
 
-	<script type="text/javascript" src="chrome-extension://dbjbempljhcmhlfpfacalomonjpalpko/scripts/inspector.js"></script>
+	<script type="text/javascript" src="chrome-extension://dbjbempljhcmhlfpfacalomonjpalpko/scripts/inspector.js">
+	</script>
 </head>
+
 <body style="width:100%;">
-        <!-- header close -->
-			<!-- header close -->
-			<!-- content begin -->
-			<div class="no-bottom no-top" id="content" style="background-size: center;">
-				<div id="top" style="background-size: cover;"></div>
-				<!-- section begin -->
-				<div><section id="bgh" class="no-top no-bottom text-light" data-stellar-background-ratio=".01" style="background-size: contain;"></div>
+	<!-- header close -->
+	<!-- header close -->
+	<!-- content begin -->
+	<div class="no-bottom no-top" id="content" style="background-size: center;">
+		<div id="top" style="background-size: cover;"></div>
+		<!-- section begin -->
+		<div>
+			<section id="bgh" class="no-top no-bottom text-light" data-stellar-background-ratio=".01"
+				style="background-size: contain;">
+		</div>
 
-					<div class="overlay-bg t90" id="all_list" style="background-size: cover;">
-						<div class="container" style="background-size: cover;">
-							<div class="row" style="background-size: cover;">
-								<div class="col-md-12 text-center" style="background-size: cover;">
-									<div class="spacer-50 sm-hide" style="background-size: cover;"></div>
-									<h1 class="no-bottom"><strong><font color="#F0F8FF">环奈功能表</font></strong></h1>
-									<p class="lead fontw3"><strong><font color="#F0F8FF">若有部分指令无响应请使用咖啡功能联系维护组</font></p>
-								</div>
-								<div class="spacer-60" style="background-size: cover;"></div>
-								<div class="col-md-8 offset-md-2" style="background-size: cover;">
-									<form class="row" id="form_subscribe" method="post" name="contactForm" onsubmit="return search();">
-										<div class="col text-center" style="background-size: cover;">
-											<div class="spacer-10" style="background-size: cover;"></div>
-											<input class="form-control" id="searchInput" name="name_1" placeholder="搜索功能或指令" type="text">
-											<a id="btn-submit" href="javascript:search()"><i class="arrow_right"></i></a>
-											<div class="clearfix" style="background-size: cover;"></div>
-										</div>
-										<div class="clearfix" style="background-size: cover;"></div>
-									</form>
-								</div>
-								<div class="spacer-60" style="background-size: cover;"></div>
-								<div class="spacer-60" style="background-size: cover;"></div>
-								<div class="spacer-60" style="background-size: cover;"></div>
-								<div class="spacer-60" style="background-size: cover;"></div>
-								<div class="spacer-60" style="background-size: cover;"></div>
-								<div class="spacer-60" style="background-size: cover;"></div>
-								<div class="spacer-60" style="background-size: cover;"></div>
-								<div class="spacer-60" style="background-size: cover;"></div>
-								<div class="col-md-10 offset-md-1" style="background-size: cover;">
-								
-									<div class="box-highlight mb40 s2" style="background-size: cover;">
-										<div class="heading text-center" style="background-size: cover;">
-											<h3>基础功能</h3>
-										</div>
-										<div class="content" style="background-size: cover;">
+		<div class="overlay-bg t90" id="all_list" style="background-size: cover;">
+			<div class="container" style="background-size: cover;">
+				<div class="row" style="background-size: cover;">
+					<div class="col-md-12 text-center" style="background-size: cover;">
+						<div class="spacer-50 sm-hide" style="background-size: cover;"></div>
+						<h1 class="no-bottom"><strong>
+								<font color="#F0F8FF">环奈功能表</font>
+							</strong></h1>
+						<p class="lead fontw3"><strong>
+								<font color="#F0F8FF">若有部分指令无响应请使用咖啡功能联系维护组</font>
+						</p>
+					</div>
+					<div class="spacer-60" style="background-size: cover;"></div>
+					<div class="col-md-8 offset-md-2" style="background-size: cover;">
+						<form class="row" id="form_subscribe" method="post" name="contactForm"
+							onsubmit="return search();">
+							<div class="col text-center" style="background-size: cover;">
+								<div class="spacer-10" style="background-size: cover;"></div>
+								<input class="form-control" id="searchInput" name="name_1" placeholder="搜索功能或指令"
+									type="text">
+								<a id="btn-submit" href="javascript:search()"><i class="arrow_right"></i></a>
+								<div class="clearfix" style="background-size: cover;"></div>
+							</div>
+							<div class="clearfix" style="background-size: cover;"></div>
+						</form>
+					</div>
+					<div class="spacer-60" style="background-size: cover;"></div>
+					<div class="spacer-60" style="background-size: cover;"></div>
+					<div class="spacer-60" style="background-size: cover;"></div>
+					<div class="spacer-60" style="background-size: cover;"></div>
+					<div class="spacer-60" style="background-size: cover;"></div>
+					<div class="spacer-60" style="background-size: cover;"></div>
+					<div class="spacer-60" style="background-size: cover;"></div>
+					<div class="spacer-60" style="background-size: cover;"></div>
+					<div class="col-md-10 offset-md-1" style="background-size: cover;">
 
-											<div class="de_table table-style-1 no-heading cols-1" style="background-size: cover;">
-												<table>
-													<thead>
-														<tr class="tr">
-															<td class="td on">名称</td>
-															<td class="td on">说明</td>
-															<td class="td on">指令</td>
-														</tr>
-													</thead>
-													<tbody>
-														<tr class="tr">
-															<td class="td on">lssv</td>
-															<td class="td on">查看本群的功能状态</td>
-															<td class="td on">lssv</br>开启+空格+功能名</br>禁用+空格+功能名</td>
-														</tr>
-																											
-														<tr class="tr">															
-															<td class="td on">_feedback_</td>
-															<td class="td on">咖啡功能，可以联系维护组</td>
-															<td class="td on">@Bot+来杯咖啡+空格+反馈内容</td>
-														</tr>
-														<tr class="tr">															
-															<td class="td on">帮助网页版</td>
-															<td class="td on">调出帮助文档的链接</td>
-															<td class="td on">帮助</td>
-														</tr>
-													</tbody>
-												</table>
+						<div class="box-highlight mb40 s2" style="background-size: cover;">
+							<div class="heading text-center" style="background-size: cover;">
+								<h3>基础功能</h3>
+							</div>
+							<div class="content" style="background-size: cover;">
+
+								<div class="de_table table-style-1 no-heading cols-1" style="background-size: cover;">
+									<table>
+										<thead>
+											<tr class="tr">
+												<td class="td on">名称</td>
+												<td class="td on">说明</td>
+												<td class="td on">指令</td>
+											</tr>
+										</thead>
+										<tbody>
+											<tr class="tr">
+												<td class="td on">lssv</td>
+												<td class="td on">查看本群的功能状态</td>
+												<td class="td on">lssv</br>开启+空格+功能名</br>禁用+空格+功能名</td>
+											</tr>
+
+											<tr class="tr">
+												<td class="td on">_feedback_</td>
+												<td class="td on">咖啡功能，可以联系维护组</td>
+												<td class="td on">@Bot+来杯咖啡+空格+反馈内容</td>
+											</tr>
+											<tr class="tr">
+												<td class="td on">帮助网页版</td>
+												<td class="td on">调出帮助文档的链接</td>
+												<td class="td on">帮助</td>
+											</tr>
+										</tbody>
+									</table>
+								</div>
+							</div>
+						</div>
+
+						<section id="all_list" style="background-size: cover;">
+							<div id="test" class="container" style="background-size: cover;">
+								<div class="row" style="background-size: cover;">
+									<div class="col text-center" style="background-size: cover;">
+										<h2 class="fontw3"><span class="uptitle id-color"></span>指令文档</h2>
+										<div class="spacer-20" style="background-size: cover;"></div>
+									</div>
+								</div>
+								<div class="row" style="background-size: cover;">
+									<div class="col-md-10 offset-md-1" style="background-size: cover;">
+										<div class="accordion" style="background-size: cover;">
+											<div class="accordion-section" style="background-size: cover;">
+
+												{% for service in services %}
+												<div class="accordion-section-title fontw3"
+													data-tab="accordion-{{service.id}}" style="background-size: cover;">
+													{{ service.name }}
+												</div>
+												<div class="accordion-section-content markdown-body"
+													id="accordion-{{service.id}}" style="background-size: cover;">
+													{{ service.help }}
+												</div>
+												{% endfor %}
 											</div>
 										</div>
 									</div>
-									
-									<section id="all_list" style="background-size: cover;">
-										<div id="test" class="container" style="background-size: cover;">
-											<div class="row" style="background-size: cover;">
-											<div class="col text-center" style="background-size: cover;">
-												<h2 class="fontw3"><span class="uptitle id-color"></span>指令文档</h2>
-												<div class="spacer-20" style="background-size: cover;"></div>
-											</div>
-											</div>
-											<div class="row" style="background-size: cover;">
-											<div class="col-md-10 offset-md-1" style="background-size: cover;">
-											<div class="accordion" style="background-size: cover;">
-												<div class="accordion-section" style="background-size: cover;">
-
-													{% for service in services %}
-													<div class="accordion-section-title fontw3"
-														data-tab="accordion-{{service.id}}" style="background-size: cover;">
-														{{ service.name }}
-													</div>
-													<div class="accordion-section-content markdown-body"
-														id="accordion-{{service.id}}" style="background-size: cover;">
-														{{ service.help }}
-													</div>
-													{% endfor %}
-												</div>
-											</div>
-											</div>
-											</div>
-										</div>
-									</section>
-
-
-									<div class="spacer-60" style="background-size: cover;"></div>
-									<div class="spacer-60" style="background-size: cover;"></div>
-									<div class="box-highlight mb40" style="background-size: cover;">
-										<div class="heading text-center" style="background-size: cover;">
-											<h3>彩蛋</h3>
-										</div>
-										<div class="content" style="background-size: cover;">
-
-											<div class="de_table table-style-1 no-heading cols-1" style="background-size: cover;">
-												<table>
-													<thead>
-														<tr class="tr">
-															<td class="td on">插件名</td>
-														</tr>
-													</thead>
-													<tbody>
-														<tr class="tr">
-															<td class="td on">有部分指令会触发彩蛋，自己摸索吧</td>
-														</tr>
-													</tbody>
-												</table>
-											</div>
-										</div>
 								</div>
-
 							</div>
+						</section>
 
+
+						<div class="spacer-60" style="background-size: cover;"></div>
+						<div class="spacer-60" style="background-size: cover;"></div>
+						<div class="box-highlight mb40" style="background-size: cover;">
+							<div class="heading text-center" style="background-size: cover;">
+								<h3>彩蛋</h3>
+							</div>
+							<div class="content" style="background-size: cover;">
+
+								<div class="de_table table-style-1 no-heading cols-1" style="background-size: cover;">
+									<table>
+										<thead>
+											<tr class="tr">
+												<td class="td on">插件名</td>
+											</tr>
+										</thead>
+										<tbody>
+											<tr class="tr">
+												<td class="td on">有部分指令会触发彩蛋，自己摸索吧</td>
+											</tr>
+										</tbody>
+									</table>
+								</div>
+							</div>
 						</div>
+
 					</div>
-			</section></div>
 
-			
-			<!-- section close -->
-
-
-		</div>
-		<!-- content close -->
-
-		<!-- footer begin -->
-		
-		<!-- footer close -->
-
-		<div id="preloader" style="background-size: cover; display: none;">
-			<div class="spinner" style="background-size: cover;">
-				<div class="bounce1" style="background-size: cover;"></div>
-				<div class="bounce2" style="background-size: cover;"></div>
-				<div class="bounce3" style="background-size: cover;"></div>
+				</div>
 			</div>
+			</section>
 		</div>
-		
 
-		<!-- Javascript Files
+
+		<!-- section close -->
+
+
+	</div>
+	<!-- content close -->
+
+	<!-- footer begin -->
+
+	<!-- footer close -->
+
+	<div id="preloader" style="background-size: cover; display: none;">
+		<div class="spinner" style="background-size: cover;">
+			<div class="bounce1" style="background-size: cover;"></div>
+			<div class="bounce2" style="background-size: cover;"></div>
+			<div class="bounce3" style="background-size: cover;"></div>
+		</div>
+	</div>
+
+
+	<!-- Javascript Files
     ================================================== -->
-		<script src="{{ url_for('static', filename='pcr/js/jquery-min.js') }}"></script>
-		<script src="{{ url_for('static', filename='pcr/js/jquery-plugin.js') }}"></script>
-		<script src="{{ url_for('static', filename='pcr/js/jquery-magnific-popup-min.js') }}"></script>
-		<script src="{{ url_for('static', filename='pcr/js/jquery-isotope-min.js') }}"></script>
-		<script src="{{ url_for('static', filename='pcr/js/jquery-countTo.js') }}"></script>
-		<script src="{{ url_for('static', filename='pcr/js/jquery-countdown.js') }}"></script>
-		<script src="{{ url_for('static', filename='pcr/js/enquire-min.js') }}"></script>
-		<script src="{{ url_for('static', filename='pcr/js/easing.js') }}"></script>
-		<script src="{{ url_for('static', filename='pcr/js/designesia.js') }}"></script>
-		<script src="{{ url_for('static', filename='pcr/js/bootstrap-min.js') }}"></script>
-		<script src="{{ url_for('static', filename='pcr/js/wow-min.js') }}"></script>
-		<script src="{{ url_for('static', filename='pcr/js/validation.js') }}"></script>
-		<script src="{{ url_for('static', filename='pcr/js/typed.js') }}"></script>
-		<script src="{{ url_for('static', filename='pcr/js/owl-carousel.js') }}"></script>
-		<script src="{{ url_for('static', filename='pcr/js/layui.js') }}"></script>
-		<script src="{{ url_for('static', filename='pcr/js/jquery-stellar-min.js') }}"></script>
-		<script src="{{ url_for('static', filename='pcr/js/jquery-ui.js') }}"></script>
-		<script src="{{ url_for('static', filename='pcr/js/particles.js') }}"></script>
-		<script src="{{ url_for('static', filename='pcr/js/app.js') }}"></script>
-	
+	<script src="{{ url_for('static', filename='pcr/js/jquery-min.js') }}"></script>
+	<script src="{{ url_for('static', filename='pcr/js/jquery-plugin.js') }}"></script>
+	<script src="{{ url_for('static', filename='pcr/js/jquery-magnific-popup-min.js') }}"></script>
+	<script src="{{ url_for('static', filename='pcr/js/jquery-isotope-min.js') }}"></script>
+	<script src="{{ url_for('static', filename='pcr/js/jquery-countTo.js') }}"></script>
+	<script src="{{ url_for('static', filename='pcr/js/jquery-countdown.js') }}"></script>
+	<script src="{{ url_for('static', filename='pcr/js/enquire-min.js') }}"></script>
+	<script src="{{ url_for('static', filename='pcr/js/easing.js') }}"></script>
+	<script src="{{ url_for('static', filename='pcr/js/designesia.js') }}"></script>
+	<script src="{{ url_for('static', filename='pcr/js/bootstrap-min.js') }}"></script>
+	<script src="{{ url_for('static', filename='pcr/js/wow-min.js') }}"></script>
+	<script src="{{ url_for('static', filename='pcr/js/validation.js') }}"></script>
+	<script src="{{ url_for('static', filename='pcr/js/typed.js') }}"></script>
+	<script src="{{ url_for('static', filename='pcr/js/owl-carousel.js') }}"></script>
+	<script src="{{ url_for('static', filename='pcr/js/layui.js') }}"></script>
+	<script src="{{ url_for('static', filename='pcr/js/jquery-stellar-min.js') }}"></script>
+	<script src="{{ url_for('static', filename='pcr/js/jquery-ui.js') }}"></script>
+	<script src="{{ url_for('static', filename='pcr/js/particles.js') }}"></script>
+	<script src="{{ url_for('static', filename='pcr/js/app.js') }}"></script>
 
-		<script>
-			// 定义首个查询下键
-			var active = 0;
 
-			function search() {
-				// 获取搜索框的值
-				var kwds = $("#searchInput").val();
-				// 获取第一个列表内容
-				var this_one = {};
-				var real_name = '';
-				// 定义数据列表
-				var list = $("#all_list .td");
-				var list_title = $("#all_list .accordion-section-title");
-				var list_content = $("#all_list .accordion-section-content");
-				list.add(list_title);
-				list.add(list_content);
-				// 定义查找的起始值
-				var true_one = 0;
-				for (var i = 0; i < list.length; i++) {
-					this_one = $(list[i]);
+	<script>
+		// 定义首个查询下键
+		var active = 0;
 
-					real_name = this_one.text().toString();
-					// 执行like匹配
-					if (real_name.match(kwds)) {
-						// 处理第当前的结果
-						if (true_one == active) {
-							// 获取窗口的宽和高
-							var windows_wdh = $(window).width();
-							var windows_hgt = $(window).height();
-							// 获取第一个坐标
-							var x_len = this_one.offset().left;
-							var y_len = this_one.offset().top;
-							// 驱动滚动条滚动到指定的位置
-							$("html,body").animate({
-								scrollTop: (y_len - windows_hgt / 2),
-								scrollLeft: (x_len - windows_wdh / 2)
-							}, 500);
-							// 标记当前选中的结果
-							this_one.addClass('active');
-							this_one.removeClass('on');
-						} else {
-							// 标记符合的结果
-							this_one.addClass('on');
-							this_one.removeClass('active');
-						}
-						// 累加真实的选择
-						true_one++;
-					} else {
+		function search() {
+			// 获取搜索框的值
+			var kwds = $("#searchInput").val();
+			// 获取第一个列表内容
+			var this_one = {};
+			var real_name = '';
+			// 定义数据列表
+			var list = $("#all_list .td");
+			var list_title = $("#all_list .accordion-section-title");
+			var list_content = $("#all_list .accordion-section-content");
+			list.add(list_title);
+			list.add(list_content);
+			// 定义查找的起始值
+			var true_one = 0;
+			for (var i = 0; i < list.length; i++) {
+				this_one = $(list[i]);
+
+				real_name = this_one.text().toString();
+				// 执行like匹配
+				if (real_name.match(kwds)) {
+					// 处理第当前的结果
+					if (true_one == active) {
+						// 获取窗口的宽和高
+						var windows_wdh = $(window).width();
+						var windows_hgt = $(window).height();
+						// 获取第一个坐标
+						var x_len = this_one.offset().left;
+						var y_len = this_one.offset().top;
+						// 驱动滚动条滚动到指定的位置
+						$("html,body").animate({
+							scrollTop: (y_len - windows_hgt / 2),
+							scrollLeft: (x_len - windows_wdh / 2)
+						}, 500);
+						// 标记当前选中的结果
+						this_one.addClass('active');
 						this_one.removeClass('on');
+					} else {
+						// 标记符合的结果
+						this_one.addClass('on');
 						this_one.removeClass('active');
 					}
+					// 累加真实的选择
+					true_one++;
+				} else {
+					this_one.removeClass('on');
+					this_one.removeClass('active');
 				}
-				// 判断是否搜索完毕 如果搜索完毕 则从第一个开始 否则继续搜索下一个
-				active = active >= true_one - 1 ? 0 : active + 1;
-
-				return false;
 			}
-		</script>
-		<script>
+			// 判断是否搜索完毕 如果搜索完毕 则从第一个开始 否则继续搜索下一个
+			active = active >= true_one - 1 ? 0 : active + 1;
+
+			return false;
+		}
+	</script>
+	<script>
 		$(function () {
 			$(".accordion-section").accordion({
 				collapsible: true,
@@ -297,54 +311,56 @@
 				animate: 100,
 				activate: function (event, ui) {
 					if (!$.isEmptyObject(ui.newHeader.offset())) {
-						$('html:not(:animated), body:not(:animated)').animate({ scrollTop: ui.newHeader.offset().top }, 'fast');
+						$('html:not(:animated), body:not(:animated)').animate({
+							scrollTop: ui.newHeader.offset().top
+						}, 'fast');
 					}
 				}
 			});
-			$('search').click(function() {
+			$('search').click(function () {
 				search();
 			})
 		});
-			// var file_urls = [];
-			// function getdata(ip,post){
-			// 	$.ajax({
-			// 	type: "get",//请求类型
-			// 	datatype: "json",//数据类型
-			// 	url: "http://"+ip+":"+post+"/autohelp/jsondata",//向哪里请求
-			// 	success: function(data){//请求成功后执行该函数
-			// 		if (data["black_list"].length>0){
-			// 			for(var key1 in data["black_list"]){
-			// 				if(data["MODULES"].indexOf(data["black_list"][key1]) != -1){
-			// 					data["MODULES"].splice(data["MODULES"].indexOf(data["black_list"][key1]), 1);
-			// 				}
-			// 			}
-			// 		};
-					
-			// 		for (var key2 in data["MODULES"]) {
-			// 			file_urls[key2] = "http://"+ip+":"+post+"/autohelp/"+data["MODULES"][key2];
-			// 		};
-					
-			// 		var a ="";
-			// 		for (var key3 in file_urls){
-			// 			a +=`<div class="accordion-section-title fontw3" data-tab="accordion-${key3}" style="background-size: cover;">`;
-			// 			a += `${data["MODULES"][key3]}`;
-			// 			a +=`</div>`;
-			// 			a +=`<div class="accordion-section-content" id="accordion-${key3}" style="background-size: cover;">`;
-			// 			a +=`<iframe src= "${file_urls[key3]}" frameBorder="0" width="1000" scrolling="yes" height="400"></iframe>`;
-			// 			a +=`</div>`;
-			// 		};
-			// 		$(".accordion-section").append(a);
-			// 		$( ".accordion-section" ).accordion({collapsible: true});
-			// 		//document.getElementById("test").innerHTML=a;
-			// 	}
-			// 	});	
-			// }
-			
-			// getdata("127.0.0.1","8080")
-			
-		</script>
-	
+		// var file_urls = [];
+		// function getdata(ip,post){
+		// 	$.ajax({
+		// 	type: "get",//请求类型
+		// 	datatype: "json",//数据类型
+		// 	url: "http://"+ip+":"+post+"/autohelp/jsondata",//向哪里请求
+		// 	success: function(data){//请求成功后执行该函数
+		// 		if (data["black_list"].length>0){
+		// 			for(var key1 in data["black_list"]){
+		// 				if(data["MODULES"].indexOf(data["black_list"][key1]) != -1){
+		// 					data["MODULES"].splice(data["MODULES"].indexOf(data["black_list"][key1]), 1);
+		// 				}
+		// 			}
+		// 		};
+
+		// 		for (var key2 in data["MODULES"]) {
+		// 			file_urls[key2] = "http://"+ip+":"+post+"/autohelp/"+data["MODULES"][key2];
+		// 		};
+
+		// 		var a ="";
+		// 		for (var key3 in file_urls){
+		// 			a +=`<div class="accordion-section-title fontw3" data-tab="accordion-${key3}" style="background-size: cover;">`;
+		// 			a += `${data["MODULES"][key3]}`;
+		// 			a +=`</div>`;
+		// 			a +=`<div class="accordion-section-content" id="accordion-${key3}" style="background-size: cover;">`;
+		// 			a +=`<iframe src= "${file_urls[key3]}" frameBorder="0" width="1000" scrolling="yes" height="400"></iframe>`;
+		// 			a +=`</div>`;
+		// 		};
+		// 		$(".accordion-section").append(a);
+		// 		$( ".accordion-section" ).accordion({collapsible: true});
+		// 		//document.getElementById("test").innerHTML=a;
+		// 	}
+		// 	});	
+		// }
+
+		// getdata("127.0.0.1","8080")
+	</script>
+
 
 
 </body>
+
 </html>

--- a/pages/templates/help.html
+++ b/pages/templates/help.html
@@ -67,7 +67,7 @@
 								</div>
 								<div class="spacer-60" style="background-size: cover;"></div>
 								<div class="col-md-8 offset-md-2" style="background-size: cover;">
-									<form class="row" id="form_subscribe" method="post" name="contactForm" action="https://pcr.botlink.xyz/help/" onsubmit="return search();">
+									<form class="row" id="form_subscribe" method="post" name="contactForm" onsubmit="return search();">
 										<div class="col text-center" style="background-size: cover;">
 											<div class="spacer-10" style="background-size: cover;"></div>
 											<input class="form-control" id="searchInput" name="name_1" placeholder="搜索功能或指令" type="text">
@@ -226,16 +226,13 @@
 		<script src="{{ url_for('static', filename='pcr/js/layui.js') }}"></script>
 		<script src="{{ url_for('static', filename='pcr/js/jquery-stellar-min.js') }}"></script>
 		<script src="{{ url_for('static', filename='pcr/js/jquery-ui.js') }}"></script>
-		<script src="{{ url_for('static', filename='pcr/js/jquery-ui.js') }}"></script>
+		<script src="{{ url_for('static', filename='pcr/js/particles.js') }}"></script>
 		<script src="{{ url_for('static', filename='pcr/js/app.js') }}"></script>
 	
 
 		<script>
 			// 定义首个查询下键
 			var active = 0;
-			$('search').click(function() {
-				search();
-			})
 
 			function search() {
 				// 获取搜索框的值
@@ -245,6 +242,10 @@
 				var real_name = '';
 				// 定义数据列表
 				var list = $("#all_list .td");
+				var list_title = $("#all_list .accordion-section-title");
+				var list_content = $("#all_list .accordion-section-content");
+				list.add(list_title);
+				list.add(list_content);
 				// 定义查找的起始值
 				var true_one = 0;
 				for (var i = 0; i < list.length; i++) {
@@ -300,6 +301,9 @@
 					}
 				}
 			});
+			$('search').click(function() {
+				search();
+			})
 		});
 			// var file_urls = [];
 			// function getdata(ip,post){

--- a/pages/templates/help.html
+++ b/pages/templates/help.html
@@ -135,8 +135,19 @@
 											<div class="row" style="background-size: cover;">
 											<div class="col-md-10 offset-md-1" style="background-size: cover;">
 											<div class="accordion" style="background-size: cover;">
-											<div class="accordion-section" style="background-size: cover;">
-											</div>
+												<div class="accordion-section" style="background-size: cover;">
+
+													{% for service in services %}
+													<div class="accordion-section-title fontw3"
+														data-tab="accordion-{{service.id}}" style="background-size: cover;">
+														{{ service.name }}
+													</div>
+													<div class="accordion-section-content"
+														id="accordion-{{service.id}}" style="background-size: cover;">
+														{{ service.help }}
+													</div>
+													{% endfor %}
+												</div>
 											</div>
 											</div>
 											</div>
@@ -276,42 +287,47 @@
 			}
 		</script>
 		<script>
-			var file_urls = [];
-			function getdata(ip,post){
-				$.ajax({
-				type: "get",//请求类型
-				datatype: "json",//数据类型
-				url: "http://"+ip+":"+post+"/autohelp/jsondata",//向哪里请求
-				success: function(data){//请求成功后执行该函数
-					if (data["black_list"].length>0){
-						for(var key1 in data["black_list"]){
-							if(data["MODULES"].indexOf(data["black_list"][key1]) != -1){
-								data["MODULES"].splice(data["MODULES"].indexOf(data["black_list"][key1]), 1);
-							}
-						}
-					};
+		$(function () {
+			$(".accordion-section").accordion({
+				collapsible: true,
+			});
+		});
+			// var file_urls = [];
+			// function getdata(ip,post){
+			// 	$.ajax({
+			// 	type: "get",//请求类型
+			// 	datatype: "json",//数据类型
+			// 	url: "http://"+ip+":"+post+"/autohelp/jsondata",//向哪里请求
+			// 	success: function(data){//请求成功后执行该函数
+			// 		if (data["black_list"].length>0){
+			// 			for(var key1 in data["black_list"]){
+			// 				if(data["MODULES"].indexOf(data["black_list"][key1]) != -1){
+			// 					data["MODULES"].splice(data["MODULES"].indexOf(data["black_list"][key1]), 1);
+			// 				}
+			// 			}
+			// 		};
 					
-					for (var key2 in data["MODULES"]) {
-						file_urls[key2] = "http://"+ip+":"+post+"/autohelp/"+data["MODULES"][key2];
-					};
+			// 		for (var key2 in data["MODULES"]) {
+			// 			file_urls[key2] = "http://"+ip+":"+post+"/autohelp/"+data["MODULES"][key2];
+			// 		};
 					
-					var a ="";
-					for (var key3 in file_urls){
-						a +=`<div class="accordion-section-title fontw3" data-tab="accordion-${key3}" style="background-size: cover;">`;
-						a += `${data["MODULES"][key3]}`;
-						a +=`</div>`;
-						a +=`<div class="accordion-section-content" id="accordion-${key3}" style="background-size: cover;">`;
-						a +=`<iframe src= "${file_urls[key3]}" frameBorder="0" width="1000" scrolling="yes" height="400"></iframe>`;
-						a +=`</div>`;
-					};
-					$(".accordion-section").append(a);
-					$( ".accordion-section" ).accordion({collapsible: true});
-					//document.getElementById("test").innerHTML=a;
-				}
-				});	
-			}
+			// 		var a ="";
+			// 		for (var key3 in file_urls){
+			// 			a +=`<div class="accordion-section-title fontw3" data-tab="accordion-${key3}" style="background-size: cover;">`;
+			// 			a += `${data["MODULES"][key3]}`;
+			// 			a +=`</div>`;
+			// 			a +=`<div class="accordion-section-content" id="accordion-${key3}" style="background-size: cover;">`;
+			// 			a +=`<iframe src= "${file_urls[key3]}" frameBorder="0" width="1000" scrolling="yes" height="400"></iframe>`;
+			// 			a +=`</div>`;
+			// 		};
+			// 		$(".accordion-section").append(a);
+			// 		$( ".accordion-section" ).accordion({collapsible: true});
+			// 		//document.getElementById("test").innerHTML=a;
+			// 	}
+			// 	});	
+			// }
 			
-			getdata("127.0.0.1","8080")
+			// getdata("127.0.0.1","8080")
 			
 		</script>
 	

--- a/pages/templates/help.html
+++ b/pages/templates/help.html
@@ -292,6 +292,13 @@
 			$(".accordion-section").accordion({
 				collapsible: true,
 				heightStyle: "content",
+				active: false,
+				animate: 100,
+				activate: function (event, ui) {
+					if (!$.isEmptyObject(ui.newHeader.offset())) {
+						$('html:not(:animated), body:not(:animated)').animate({ scrollTop: ui.newHeader.offset().top }, 'fast');
+					}
+				}
 			});
 		});
 			// var file_urls = [];

--- a/static/pcr/css/markdown.css
+++ b/static/pcr/css/markdown.css
@@ -1,0 +1,309 @@
+/*
+ * github like style
+ * https://github.com/iamcco/markdown.css/blob/master/dest/github/markdown.css
+ */
+
+ :root {
+    --color-text-primary: #333;
+    --color-text-tertiary: #777;
+    --color-text-link: #4078c0;
+    --color-bg-primary: #fff;
+    --color-bg-secondary: #fafbfc;
+    --color-bg-tertiary: #f8f8f8;
+    --color-border-primary: #ddd;
+    --color-border-secondary: #eaecef;
+    --color-border-tertiary: #d1d5da;
+    --color-kbd-foreground: #444d56;
+    --color-markdown-blockquote-border: #dfe2e5;
+    --color-markdown-table-border: #dfe2e5;
+    --color-markdown-table-tr-border: #c6cbd1;
+    --color-markdown-code-bg: #1b1f230d;
+}
+[data-theme="dark"] {
+    --color-text-primary: #c9d1d9;
+    --color-text-tertiary: #8b949e;
+    --color-text-link: #58a6ff;
+    --color-bg-primary: #0d1117;
+    --color-bg-secondary: #0d1117;
+    --color-bg-tertiary: #161b22;
+    --color-border-primary: #30363d;
+    --color-border-secondary: #21262d;
+    --color-border-tertiary: #6e7681;
+    --color-kbd-foreground: #b1bac4;
+    --color-markdown-blockquote-border: #3b434b;
+    --color-markdown-table-border: #3b434b;
+    --color-markdown-table-tr-border: #272c32;
+    --color-markdown-code-bg: #f0f6fc26;
+}
+
+.markdown-body ol ol,
+.markdown-body ul ol,
+.markdown-body ol ul,
+.markdown-body ul ul,
+.markdown-body ol ul ol,
+.markdown-body ul ul ol,
+.markdown-body ol ul ul,
+.markdown-body ul ul ul {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+.markdown-body {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-size: 16px;
+  color: var(--color-text-primary);
+  line-height: 1.6;
+  word-wrap: break-word;
+  padding: 45px;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border-primary);
+  -webkit-border-radius: 0 0 3px 3px;
+  border-radius: 0 0 3px 3px;
+}
+.markdown-body > *:first-child {
+  margin-top: 0 !important;
+}
+.markdown-body > *:last-child {
+  margin-bottom: 0 !important;
+}
+.markdown-body .table-of-contents ol {
+  list-style: none;
+}
+.markdown-body .table-of-contents > ol {
+  padding-left: 0;
+}
+.markdown-body * {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+  margin-top: 1em;
+  margin-bottom: 16px;
+  font-weight: bold;
+  line-height: 1.4;
+}
+.markdown-body h1 .anchor,
+.markdown-body h2 .anchor,
+.markdown-body h3 .anchor,
+.markdown-body h4 .anchor,
+.markdown-body h5 .anchor,
+.markdown-body h6 .anchor {
+  margin-left: -24px;
+  visibility: hidden;
+}
+.markdown-body h1:hover .anchor,
+.markdown-body h2:hover .anchor,
+.markdown-body h3:hover .anchor,
+.markdown-body h4:hover .anchor,
+.markdown-body h5:hover .anchor,
+.markdown-body h6:hover .anchor {
+  visibility: visible;
+}
+.markdown-body p,
+.markdown-body blockquote,
+.markdown-body ul,
+.markdown-body ol,
+.markdown-body dl,
+.markdown-body table,
+.markdown-body pre {
+  margin-top: 0;
+  margin-bottom: 16px;
+}
+.markdown-body h1 {
+  margin: 0.67em 0;
+  padding-bottom: 0.3em;
+  font-size: 2.25em;
+  line-height: 1.2;
+  border-bottom: 1px solid var(--color-border-secondary);
+}
+.markdown-body h2 {
+  padding-bottom: 0.3em;
+  font-size: 1.75em;
+  line-height: 1.225;
+  border-bottom: 1px solid var(--color-border-secondary);
+}
+.markdown-body h3 {
+  font-size: 1.5em;
+  line-height: 1.43;
+}
+.markdown-body h4 {
+  font-size: 1.25em;
+}
+.markdown-body h5 {
+  font-size: 1em;
+}
+.markdown-body h6 {
+  font-size: 1em;
+  color: var(--color-text-tertiary);
+}
+.markdown-body hr {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  height: 0;
+  border: 0;
+  border-top: 1px solid var(--color-border-primary);
+}
+.markdown-body ol,
+.markdown-body ul {
+  padding-left: 2em;
+}
+.markdown-body ol ol,
+.markdown-body ul ol {
+  list-style-type: lower-roman;
+}
+.markdown-body ol ul,
+.markdown-body ul ul {
+  list-style-type: circle;
+}
+.markdown-body ol ul ul,
+.markdown-body ul ul ul {
+  list-style-type: square;
+}
+.markdown-body ol {
+  list-style-type: decimal;
+}
+.markdown-body ul {
+  list-style-type: disc;
+}
+.markdown-body dl {
+  margin-bottom: 1.3em
+}
+.markdown-body dl dt {
+  font-weight: 700;
+}
+.markdown-body dl dd {
+  margin-left: 0;
+}
+.markdown-body dl dd p {
+  margin-bottom: 0.8em;
+}
+.markdown-body blockquote {
+  margin-left: 0;
+  margin-right: 0;
+  padding: 0 15px;
+  color: var(--color-text-tertiary);
+  border-left: 4px solid var(--color-markdown-blockquote-border);
+}
+.markdown-body table {
+  display: block;
+  width: 100%;
+  overflow: auto;
+  word-break: break-word;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+.markdown-body table tr {
+  background-color: var(--color-bg-primary);
+  border-top: 1px solid var(--color-markdown-table-tr-border);
+}
+.markdown-body table tr:nth-child(2n) {
+  background-color: var(--color-bg-tertiary);
+}
+.markdown-body table th,
+.markdown-body table td {
+  padding: 6px 13px;
+  border: 1px solid var(--color-markdown-table-border);
+}
+.markdown-body kbd {
+  display: inline-block;
+  padding: 5px 6px;
+  font: 14px SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace;
+  line-height: 10px;
+  color: var(--color-kbd-foreground);
+  vertical-align: middle;
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-tertiary);
+  border-radius: 3px;
+  box-shadow: inset 0 -1px 0 var(--color-border-tertiary);
+}
+.markdown-body pre {
+  word-wrap: break-word;
+  padding: 16px;
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+  background-color: var(--color-bg-tertiary);
+  -webkit-border-radius: 3px;
+  border-radius: 3px;
+}
+.markdown-body pre code {
+  display: inline;
+  max-width: initial;
+  padding: 0;
+  margin: 0;
+  overflow: initial;
+  font-size: 100%;
+  line-height: inherit;
+  word-wrap: break-word;
+  white-space: pre;
+  border: 0;
+  -webkit-border-radius: 3px;
+  border-radius: 3px;
+  background-color: transparent;
+}
+.markdown-body pre code:before,
+.markdown-body pre code:after {
+  content: normal;
+}
+.markdown-body code {
+  font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  padding: 0;
+  padding-top: 0.2em;
+  padding-bottom: 0.2em;
+  margin: 0;
+  font-size: 85%;
+  background-color: var(--color-markdown-code-bg);
+  -webkit-border-radius: 3px;
+  border-radius: 3px;
+}
+.markdown-body code:before,
+.markdown-body code:after {
+  letter-spacing: -0.2em;
+  content: "\00a0";
+}
+.markdown-body a {
+  color: var(--color-text-link);
+  text-decoration: none;
+  background: transparent;
+}
+.markdown-body img {
+  max-width: 100%;
+  max-height: 100%;
+}
+.markdown-body strong {
+  font-weight: bold;
+}
+.markdown-body em {
+  font-style: italic;
+}
+.markdown-body del {
+  text-decoration: line-through;
+}
+.task-list-item {
+  list-style-type: none;
+}
+.task-list-item input {
+  font: 13px/1.4 Helvetica, arial, nimbussansl, liberationsans, freesans, clean, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  margin: 0 0.35em 0.25em -1.6em;
+  vertical-align: middle;
+}
+.task-list-item input[disabled] {
+  cursor: default;
+}
+.task-list-item input[type="checkbox"] {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  padding: 0;
+}
+.task-list-item input[type="radio"] {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  padding: 0;
+}

--- a/static/pcr/js/designesia.js
+++ b/static/pcr/js/designesia.js
@@ -1265,16 +1265,16 @@
          sequence();
          sequence_a();
 	
-		$('.accordion-section-title').click(function(e){
-         var currentAttrvalue = $(this).data('tab');
-         if($(e.target).is('.active')){
-             $(this).removeClass('active');
-             $('.accordion-section-content:visible').slideUp(300);
-         } else {
-             $('.accordion-section-title').removeClass('active').filter(this).addClass('active');
-             $('.accordion-section-content').slideUp(300).filter(currentAttrvalue).slideDown(300);
-         }
-     });
+	// 	$('.accordion-section-title').click(function(e){
+    //      var currentAttrvalue = $(this).data('tab');
+    //      if($(e.target).is('.active')){
+    //          $(this).removeClass('active');
+    //          $('.accordion-section-content:visible').slideUp(300);
+    //      } else {
+    //          $('.accordion-section-title').removeClass('active').filter(this).addClass('active');
+    //          $('.accordion-section-content').slideUp(300).filter(currentAttrvalue).slideDown(300);
+    //      }
+    //  });
 		
 
          /* --------------------------------------------------


### PR DESCRIPTION
针对 #6 所做的一些改进
- 网站从客户端渲染改成服务端渲染
- 新增了选择放出`modules`还是`services`的帮助选项。因为一个`modules`可能有不同的`services`，且`services`名和`modules`名可能不一致，以及个人能力有限，没能实现像`dalao`所想的先读`userreadme`，再`help`，最后`readme`文案的功能。其中`services`会用其`help`信息作为帮助文案
- 新增`markdown`的`css`样式
- 注释了自定义的折叠菜单函数。`JQuery`也定义好默认函数，两个一起好像会导致关闭折叠菜单时行为异常 Fixes #6 
- 帮助文案的高度可以自适应
- 新增打开折叠菜单后页面保持该菜单在浏览界面的特性。因为如果打开菜单`a`，帮助文案很长，再打开下面的菜单`b`时，因为`a`帮助文案自动关闭时整体页面往上移动导致需要向上滑动页面才能看到`b`的帮助
- 扩大了搜索范围，先前搜索范围仅限于`基础功能`和`彩蛋`，现在将`指令文档`也纳入搜索范围
- 插件按照插件名的字典序进行排序排列
- 修复了部分`error`

(但感觉`help.html`还是有点冗余
因为我还用了[网页版插件开关管理系统](https://github.com/pcrbot/HosBotManagerWeb)，所以其地址我是放在了`config.__bot__`里，可以直接引用那里地址而不是该文件额外开个变量。